### PR TITLE
django.conf.urls.defaults fix for django 1.6+

### DIFF
--- a/faq/admin.py
+++ b/faq/admin.py
@@ -8,6 +8,7 @@ class QuestionAdmin(admin.ModelAdmin):
     list_display = ['text', 'sort_order', 'created_by', 'created_on',
                     'updated_by', 'updated_on', 'status']
     list_editable = ['sort_order', 'status']
+    raw_id_fields = ['created_by', 'updated_by']
 
     def save_model(self, request, obj, form, change): 
         '''

--- a/faq/managers.py
+++ b/faq/managers.py
@@ -9,7 +9,7 @@ class QuestionQuerySet(QuerySet):
         return self.filter(status__exact=self.model.ACTIVE)
 
 class QuestionManager(models.Manager):
-    def get_query_set(self):
+    def get_queryset(self):
         return QuestionQuerySet(self.model)
 
     def active(self):

--- a/faq/managers.py
+++ b/faq/managers.py
@@ -13,4 +13,4 @@ class QuestionManager(models.Manager):
         return QuestionQuerySet(self.model)
 
     def active(self):
-        return self.getquery_set().active()
+        return self.get_queryset().active()

--- a/faq/managers.py
+++ b/faq/managers.py
@@ -13,4 +13,4 @@ class QuestionManager(models.Manager):
         return QuestionQuerySet(self.model)
 
     def active(self):
-        return self.get_query_set().active()
+        return self.getquery_set().active()

--- a/faq/models.py
+++ b/faq/models.py
@@ -1,9 +1,15 @@
-import datetime
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from django.contrib.auth.models import User
 from django.template.defaultfilters import slugify
 from managers import QuestionManager
+from django.conf import settings
+
+if settings.USE_TZ:
+    from django.utils.timezone import now as datetime_now
+else:
+    import datetime
+    datetime_now = datetime.datetime.now
 
 class Topic(models.Model):
     """
@@ -51,7 +57,7 @@ class Question(models.Model):
     sort_order = models.IntegerField(_('sort order'), default=0,
         help_text=_('The order you would like the question to be displayed.'))
 
-    created_on = models.DateTimeField(_('created on'), default=datetime.datetime.now)
+    created_on = models.DateTimeField(_('created on'), default=datetime_now)
     updated_on = models.DateTimeField(_('updated on'))
     created_by = models.ForeignKey(User, verbose_name=_('created by'),
         null=True, related_name="+")
@@ -70,7 +76,7 @@ class Question(models.Model):
 
     def save(self, *args, **kwargs):
         # Set the date updated.
-        self.updated_on = datetime.datetime.now()
+        self.updated_on = datetime_now()
         
         # Create a unique slug, if needed.
         if not self.slug:

--- a/faq/urls.py
+++ b/faq/urls.py
@@ -1,6 +1,12 @@
 from __future__ import absolute_import
 
-from django.conf.urls.defaults import *
+try:
+    # Django > 1.6
+    from django.conf.urls import patterns, include, url
+except ImportError:
+    # Django < 1.6
+    from django.conf.urls.defaults import patterns, include, url
+
 from . import views as faq_views
 
 urlpatterns = patterns('',


### PR DESCRIPTION
The location of django django.conf.urls.defaults was changed to
django.conf.urls in django 1.4
https://docs.djangoproject.com/en/1.4/releases/1.4/#django-conf-urls-defaults

This code allows both to work
