### PR TITLE
Adding Django 1.6 support

### DIFF
--- a/example/manage.py
+++ b/example/manage.py
@@ -9,13 +9,10 @@ except ImportError:
     sys.stderr.write("django-faq isn't installed; trying to use a source checkout in ../faq.")
     sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from django.core.management import execute_manager
-try:
-    import settings # Assumed to be in the same directory.
-except ImportError:
-    import sys
-    sys.stderr.write("Error: Can't find the file 'settings.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n(If the file settings.py does indeed exist, it's causing an ImportError somehow.)\n" % __file__)
-    sys.exit(1)
-
 if __name__ == "__main__":
-    execute_manager(settings)
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "example.settings")
+
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)
+

--- a/example/urls.py
+++ b/example/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url, include
+from django.conf.urls import patterns, url, include
 from django.contrib import admin; admin.autodiscover()
 from django.conf import settings
 from django.views.generic import TemplateView

--- a/faq/urls.py
+++ b/faq/urls.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 from . import views as faq_views
 
 urlpatterns = patterns('',


### PR DESCRIPTION
Made changes necessary to support Django >= 1.6.

Changes include:
- Removal of deprecated `from django.core.management import execute_manager` import
- Modified import for URL conf -- updated to `from django.conf.urls import *`
